### PR TITLE
The Flickr provider no longer functioned in Laravel 5.4 due to update…

### DIFF
--- a/src/Flickr/Server.php
+++ b/src/Flickr/Server.php
@@ -21,7 +21,11 @@ class Server extends BaseServer
      */
     public function urlAuthorization()
     {
-        return 'https://www.flickr.com/services/oauth/authorize';
+        $parameters = '';
+        if(property_exists($this, 'parameters') && is_array($this->params))
+            $parameters = http_build_query($this->parameters);
+
+        return 'https://www.flickr.com/services/oauth/authorize?' . $parameters;
     }
 
     /**
@@ -104,8 +108,8 @@ class Server extends BaseServer
 
         $client = $this->createHttpClient();
 
-        $response = $client->get($url)->send();
+        $response = $client->get($url);
 
-        return $response->json();
+        return json_decode($response->getBody(),true);
     }
 }


### PR DESCRIPTION
…s to the supplied Guzzle library. Also Flickr requires the "perms" variable (Acceptable values: read, write, delete) to be supplied with the authorization request. Both issues are addressed in this commit.

